### PR TITLE
Add pygobject build dependencies to package install list for Gtk+ image

### DIFF
--- a/tasks/gtk-py34/Dockerfile
+++ b/tasks/gtk-py34/Dockerfile
@@ -10,6 +10,9 @@ ADD . /app
 # Install GTK+3 python bindings
 RUN apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0
 
+# Install pygobject build dependencies
+RUN apt-get install -y python3-dev libgirepository1.0-dev libcairo2-dev pkg-config
+
 # `gi` is installed to /usr/lib/python3/dist-packages, which is not in the
 # python path by default.
 ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages/


### PR DESCRIPTION
These build dependencies are needed in order to pass beekeeper tests for pybee/toga#442. The build dependencies allow pycairo and pygobject to be built when they are installed as setup.py dependencies.

Signed-off-by: Dan Yeaw <dan@yeaw.me>